### PR TITLE
Use wasmExports instead of obsolete asm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.7.3]
+* The `wasmExports` is used instead of the obsolete `asm`.
+* The sdk version is upgraded up to 3.0.0.
+
 ## [0.7.2]
 * Fixed errors related to unexpected `runtimeType` names due to minifying in release builds
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is a fork of the package [web_ffi](https://pub.dev/packages/web_ffi) on pub.dev, and this package uses `wasmExports` instead of the obsolete `asm`.
+
 # web_ffi
 `web_ffi` is a drop-in solution for using `dart:ffi` on the web. This enables you to work with `WebAssembly` more easily and convenient.
 

--- a/example/example_flutter/lib/src/init_web.dart
+++ b/example/example_flutter/lib/src/init_web.dart
@@ -1,4 +1,3 @@
-import 'dart:typed_data';
 import 'package:flutter/services.dart';
 import 'package:inject_js/inject_js.dart' as Js;
 // Notice that in this file, we import web_ffi and not proxy_ffi.dart

--- a/example/example_flutter/pubspec.lock
+++ b/example/example_flutter/pubspec.lock
@@ -5,16 +5,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.18.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -24,48 +26,53 @@ packages:
     dependency: "direct main"
     description:
       name: inject_js
-      url: "https://pub.dartlang.org"
+      sha256: "3ab213e2c76375a611f57eb0044d32c6e18c5091d52510e7fe9f88f6bee83d19"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.7"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.15.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.99"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.4"
   web_ffi:
     dependency: "direct main"
     description:
       path: "../.."
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.7.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=3.3.0-0 <4.0.0"

--- a/example/example_no_flutter/pubspec.lock
+++ b/example/example_no_flutter/pubspec.lock
@@ -5,22 +5,24 @@ packages:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.7"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.16.0"
   web_ffi:
     dependency: "direct main"
     description:
       path: "../.."
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.7.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"

--- a/lib/src/modules/emscripten/emscripten_module.dart
+++ b/lib/src/modules/emscripten/emscripten_module.dart
@@ -19,6 +19,7 @@ class _EmscriptenModuleJs {
   external Uint8List? get wasmBinary;
   external Uint8List? get HEAPU8;
   external Object? get asm;
+  external Object? get wasmExports;
 
   // Must have an unnamed factory constructor with named arguments.
   external factory _EmscriptenModuleJs({Uint8List wasmBinary});
@@ -108,13 +109,13 @@ class EmscriptenModule extends Module {
       this._emscriptenModuleJs, this._exports, this._malloc, this._free);
 
   factory EmscriptenModule._fromJs(_EmscriptenModuleJs module) {
-    Object? asm = module.asm;
-    if (asm != null) {
+    final wasmExports = module.wasmExports ?? module.asm;
+    if (wasmExports != null) {
       Map<int, WasmSymbol> knownAddresses = {};
       _Malloc? malloc;
       _Free? free;
       List<WasmSymbol> exports = [];
-      List? entries = _entries(asm);
+      List? entries = _entries(wasmExports);
       if (entries != null) {
         for (dynamic entry in entries) {
           if (entry is List) {

--- a/lib/src/modules/module.dart
+++ b/lib/src/modules/module.dart
@@ -65,13 +65,9 @@ class Global extends WasmSymbol {
       : super(address: address, name: name);
 
   @override
-  bool operator ==(dynamic other) {
-    if (other != null && other is Global) {
-      return name == other.name && address == other.address;
-    } else {
-      return false;
-    }
-  }
+  bool operator ==(Object other) => other is Global
+    && name == other.name
+    && address == other.address;
 }
 
 /// Describes a function exported from WebAssembly.
@@ -98,15 +94,10 @@ class FunctionDescription extends WasmSymbol {
   int get hashCode => '$name$argumentCount$tableIndex'.hashCode;
 
   @override
-  bool operator ==(dynamic other) {
-    if (other != null && other is FunctionDescription) {
-      return argumentCount == other.argumentCount &&
-          name == other.name &&
-          tableIndex == other.tableIndex;
-    } else {
-      return false;
-    }
-  }
+  bool operator ==(Object other) => other is FunctionDescription
+    && argumentCount == other.argumentCount
+    && name == other.name
+    && tableIndex == other.tableIndex;
 
   @override
   String toString() =>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,15 +5,17 @@ packages:
     dependency: "direct main"
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.7"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.16.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,13 @@
 name: web_ffi
-version: 0.7.2
-repository: https://github.com/EPNW/web_ffi/
+version: 0.7.3
 description: Translates dart:ffi calls on the web to WebAssembly using dart:js
+repository: https://github.com/darkstarx/web_ffi
+
+publish_to: https://pub.rightbrain.pro
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
+
 dependencies:
   js: ^0.6.3
   meta: ^1.3.0


### PR DESCRIPTION
It's related to #10.

New versions of Emscripten declares the `Model.asm` as deprecated and generates the getter `asm` which aborts with corresponding message:

```javascript
legacyModuleProp('asm', 'wasmExports');
...
function legacyModuleProp(prop, newName, incomming=true) {
  if (!Object.getOwnPropertyDescriptor(Module, prop)) {
    Object.defineProperty(Module, prop, {
      configurable: true,
      get() {
        let extra = incomming ? ' (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name)' : '';
        abort(`\`Module.${prop}\` has been replaced by \`${newName}\`` + extra);

      }
    });
  }
}
...
missingGlobal('asm', 'Please use wasmExports instead');
```

So, to keep old versions of Emscripten supported as well as new versions, this PR is offered.